### PR TITLE
Update fontbakery check-IDs in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ install: otf
 
 test: ttf otf $(PDFS)
 	fontbakery check-ufo-sources $(SRCDIR)/*.ufo
-	fontbakery check-googlefonts -x com.google.fonts/check/029 -x com.google.fonts/check/117 $(BLDDIR)/*.ttf
+	fontbakery check-googlefonts -x com.google.fonts/check/name/license -x com.google.fonts/check/version_bump $(BLDDIR)/*.ttf
 	fontbakery check-fontval $(BLDDIR)/*.ttf
 	fontbakery check-opentype $(BLDDIR)/*.otf
 


### PR DESCRIPTION
Fontbakery nowadays uses keyword-based check IDs